### PR TITLE
Add "deep" support for `nullable=True`

### DIFF
--- a/porter/schemas/openapi.py
+++ b/porter/schemas/openapi.py
@@ -182,11 +182,18 @@ class Object(ApiObject):
 
 
 def _to_jsonschema(obj):
-    # While `nullable` is part of the OpenAPI 3 spec, is not supported by
-    # JSONSchema draft-04 which we use for validations (see reference above).
-    # Thus we have whether null values are allowed ourselves and dispatch the
-    # rest to `fastjsonschema`
+    """Recurse through `obj` converting from OpenAPI to JsonSchema.
+
+    Args:
+        obj (dict): An OpenAPI object representing a data type.
+    """
     if isinstance(obj, dict):
+        # While `nullable` is part of the OpenAPI 3 spec, it is not supported by
+        # JSONSchema draft-04 which we use for validations (see reference above).
+        # As a work-around we define the object as multiple types (this time
+        # supported by JsonSchema but not OpenAPI).
+        # See the secion "Mixed Types" here
+        # https://swagger.io/docs/specification/data-models/data-types/
         nullable = obj.pop('nullable', False)
         if nullable:
             obj['type'] = [obj['type'], 'null']

--- a/tests/test_schemas_openapi.py
+++ b/tests/test_schemas_openapi.py
@@ -47,11 +47,11 @@ class TestString(unittest.TestCase):
 
     def test_nullable(self):
         # check nullable
-        s = String('is nullable', nullable=True)
+        s = String('is nullable', additional_params=dict(nullable=True))
         s.validate('foo')
         s.validate(None)
 
-        s = String('is not nullable', nullable=False)
+        s = String('is not nullable', additional_params=dict(nullable=False))
         s.validate('foo')
         with self.assertRaisesRegex(
                 ValueError, 'Schema validation failed: data must be string'):
@@ -80,11 +80,11 @@ class TestNumber(unittest.TestCase):
 
     def test_nullable(self):
         # check nullable
-        n = Number('is nullable', nullable=True)
+        n = Number('is nullable', additional_params=dict(nullable=True))
         n.validate(1.)
         n.validate(None)
 
-        n = Number('is not nullable', nullable=False)
+        n = Number('is not nullable', additional_params=dict(nullable=False))
         n.validate(1.)
         with self.assertRaisesRegex(
                 ValueError, 'Schema validation failed: data must be number'):
@@ -115,11 +115,11 @@ class TestInteger(unittest.TestCase):
 
     def test_nullable(self):
         # check nullable
-        i = Integer('is nullable', nullable=True)
+        i = Integer('is nullable', additional_params=dict(nullable=True))
         i.validate(1)
         i.validate(None)
 
-        i = Integer('is not nullable', nullable=False)
+        i = Integer('is not nullable', additional_params=dict(nullable=False))
         i.validate(1)
         with self.assertRaisesRegex(
                 ValueError, 'Schema validation failed: data must be integer'):
@@ -140,11 +140,11 @@ class TestBoolean(unittest.TestCase):
 
     def test_nullable(self):
         # check nullable
-        b = Boolean('is nullable', nullable=True)
+        b = Boolean('is nullable', additional_params=dict(nullable=True))
         b.validate(True)
         b.validate(None)
 
-        b = Boolean('is not nullable', nullable=False)
+        b = Boolean('is not nullable', additional_params=dict(nullable=False))
         b.validate(True)
         with self.assertRaisesRegex(
                 ValueError, 'Schema validation failed: data must be boolean'):
@@ -169,11 +169,11 @@ class TestArray(unittest.TestCase):
 
     def test_nullable(self):
         # check nullable
-        a = Array('is nullable', item_type=Integer(), nullable=True)
+        a = Array('is nullable', item_type=Integer(), additional_params=dict(nullable=True))
         a.validate([1])
         a.validate(None)
 
-        a = Array('is not nullable', item_type=Integer(), nullable=False)
+        a = Array('is not nullable', item_type=Integer(), additional_params=dict(nullable=False))
         a.validate([1])
         with self.assertRaisesRegex(
                 ValueError, 'Schema validation failed: data must be array'):
@@ -181,7 +181,7 @@ class TestArray(unittest.TestCase):
 
     def test_nullable_item_type(self):
         # check nullable
-        a = Array('is nullable', item_type=Integer(nullable=True))
+        a = Array('is nullable', item_type=Integer(additional_params=dict(nullable=True)))
         a.validate([1])
         a.validate([1, None])
 
@@ -217,11 +217,11 @@ class TestObject(unittest.TestCase):
 
     def test_nullable(self):
         # check nullable
-        o = Object('is nullable', additional_properties_type=Integer(), nullable=True)
+        o = Object('is nullable', additional_properties_type=Integer(), additional_params=dict(nullable=True))
         o.validate({'a': 1})
         o.validate(None)
 
-        o = Object('is not nullable', additional_properties_type=Integer(), nullable=False)
+        o = Object('is not nullable', additional_properties_type=Integer(), additional_params=dict(nullable=False))
         o.validate({'a': 1})
         with self.assertRaisesRegex(
                 ValueError, 'Schema validation failed: data must be object'):
@@ -229,7 +229,7 @@ class TestObject(unittest.TestCase):
 
     def test_nested_nullable(self):
         # check nullable
-        o = Object('is nullable', additional_properties_type=Integer(nullable=True))
+        o = Object('is nullable', additional_properties_type=Integer(additional_params=dict(nullable=True)))
         o.validate({'a': 1})
         o.validate({'a': None})
 
@@ -240,7 +240,7 @@ class TestObject(unittest.TestCase):
             o.validate({'a': None})
 
     def test_additional_properties_type(self):
-        o = Object('is nullable', additional_properties_type=Integer(nullable=True))
+        o = Object('is nullable', additional_properties_type=Integer(additional_params=dict(nullable=True)))
         o.validate({'a': 1, 'b': None})
 
 
@@ -251,11 +251,11 @@ class TestComplexObject(unittest.TestCase):
             properties=dict(
                 a=Object(
                     properties=dict(
-                        aa=String(additional_params=dict(minLength=3), nullable=True),
+                        aa=String(additional_params=dict(minLength=3, nullable=True)),
                         bb=Object(
                             properties=dict(
                                 ccc=Array(
-                                    item_type=Integer(nullable=True),
+                                    item_type=Integer(additional_params=dict(nullable=True)),
                                     additional_params=dict(minItems=3))
                             )
                         )


### PR DESCRIPTION
This extends #11 to add "deep" support for `nullable` objects that are nested inside of `Object` or `Array`.

To do so we add a simple layer to translate from OpenAPI to JsonSchema, in the special case that `nullable=True`, otherwise we leave the specs alone.